### PR TITLE
Add homework/branch kubernetes-monitoring

### DIFF
--- a/kubernetes-monitoring/Readme.md
+++ b/kubernetes-monitoring/Readme.md
@@ -1,16 +1,29 @@
 Запустить проект:
+
 minikube start --memory 4096 --cpus 4
+
 cd $KUBERNETES_MONITORING_DIR
+
 kubectl create ns prometheus-operator
-helm upgrade --install prometheus-operator stable/prometheus-operator --wait -
-namespace=prometheus-operator -f values.yaml
+
+helm upgrade --install prometheus-operator stable/prometheus-operator --wait -namespace=prometheus-operator -f values.yaml
+
 kubectl port-forward -n prometheus-operator service/prometheus-operator-grafana 8080:80
+
 kubectl appyl -f { <deployment, service, service-monitor> }
+
 OPTIONAL:
+
 kubectl port-forward -n monitoring service/nginx-monitoring 9113:9113
+
 kubectl port-forward -n monitoring service/nginx-monitoring 8888:8888
 
+
+
 Проверить работоспособность:
+
 Grafana - http://localhost:8080
+
 Check - http://localhost:8888/basic_status
+
 Check - http://localhost:9113/metrics

--- a/kubernetes-monitoring/Readme.md
+++ b/kubernetes-monitoring/Readme.md
@@ -1,0 +1,16 @@
+Запустить проект:
+minikube start --memory 4096 --cpus 4
+cd $KUBERNETES_MONITORING_DIR
+kubectl create ns prometheus-operator
+helm upgrade --install prometheus-operator stable/prometheus-operator --wait -
+namespace=prometheus-operator -f values.yaml
+kubectl port-forward -n prometheus-operator service/prometheus-operator-grafana 8080:80
+kubectl appyl -f { <deployment, service, service-monitor> }
+OPTIONAL:
+kubectl port-forward -n monitoring service/nginx-monitoring 9113:9113
+kubectl port-forward -n monitoring service/nginx-monitoring 8888:8888
+
+Проверить работоспособность:
+Grafana - http://localhost:8080
+Check - http://localhost:8888/basic_status
+Check - http://localhost:9113/metrics

--- a/kubernetes-monitoring/deployment.yaml
+++ b/kubernetes-monitoring/deployment.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name:  monitoring
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: monitoring
+  namespace: monitoring
+  labels:
+    app: nginx-monitoring
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx-monitoring
+  template:
+    metadata:
+      labels:
+        app: nginx-monitoring
+    spec:
+      containers:
+      - name: nginx
+        image: yerlanagzhigitov/otus-homework-monitoring:v1.0
+        ports:
+          - name: nginx-port
+            containerPort: 8888
+      - name: nginx-exporter
+        image: nginx/nginx-prometheus-exporter:0.5.0
+        args:
+        - -nginx.scrape-uri=http://localhost:8888/basic_status
+        ports:
+          - name: nginx-exporter
+            containerPort: 9113

--- a/kubernetes-monitoring/nginx/Dockerfile
+++ b/kubernetes-monitoring/nginx/Dockerfile
@@ -1,0 +1,8 @@
+FROM nginx:stable
+
+# Create app directory
+WORKDIR /app
+ADD conf.d /etc/nginx/conf.d
+ADD app /app
+
+CMD /usr/sbin/nginx -g 'daemon off;'

--- a/kubernetes-monitoring/nginx/app/index.html
+++ b/kubernetes-monitoring/nginx/app/index.html
@@ -1,0 +1,5 @@
+<html>
+
+<h1>Yerlan. Homework kubernetes-monitoring</h1>
+
+</html>

--- a/kubernetes-monitoring/nginx/conf.d/default.conf
+++ b/kubernetes-monitoring/nginx/conf.d/default.conf
@@ -1,0 +1,16 @@
+server {
+    listen       8888;
+    server_name  localhost;
+
+    location / {
+        root   /app;
+    }
+    
+    location /basic_status {
+        stub_status on;
+
+        access_log on;
+	    allow all;
+        deny all;
+    }    
+}

--- a/kubernetes-monitoring/service-monitor.yaml
+++ b/kubernetes-monitoring/service-monitor.yaml
@@ -1,0 +1,13 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: nginx-monitoring
+  namespace: monitoring
+  labels:
+    app: nginx-monitoring
+spec:
+  selector:
+    matchLabels:
+      app: nginx-monitoring
+  endpoints:
+  - port: nginx-exporter

--- a/kubernetes-monitoring/service.yaml
+++ b/kubernetes-monitoring/service.yaml
@@ -1,0 +1,20 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: nginx-monitoring
+  namespace: monitoring
+  labels:
+    app: nginx-monitoring
+spec:
+  type: NodePort
+  selector:
+    app: nginx-monitoring
+  ports:
+   - name: nginx-port
+     protocol: TCP
+     port: 8888
+     targetPort: 8888
+   - name: nginx-exporter
+     protocol: TCP
+     port: 9113
+     targetPort: 9113

--- a/kubernetes-monitoring/values.yaml
+++ b/kubernetes-monitoring/values.yaml
@@ -1,0 +1,13 @@
+prometheus:
+  prometheusSpec:
+     retention: 2d
+     ### Check this labels: kubectl get prometheus -o yaml -n monitoring
+     serviceMonitorNamespaceSelector: {} ### Namespace for ServiceMonitors select
+     serviceMonitorSelectorNilUsesHelmValues: false
+     serviceMonitorSelector: {} ### matchLabels for ServiceMonitors select
+     # serviceMonitorSelector:
+     # matchLabels:
+     # prometheus: kube-prometheus
+     # release: prometheus-cluster-monitoring
+grafana:
+  adminPassword: admin


### PR DESCRIPTION
 # Выполнено ДЗ 7

 - [+] Основное ДЗ
 - [ ] Задание со *

## В процессе сделано:
 - Создан branch kubernetes-monitoring
 - 
## Как запустить проект:
 - minikube start --memory 4096 --cpus 4
 - cd $KUBERNETES_MONITORING_DIR
 - kubectl create ns prometheus-operator
 - helm upgrade --install prometheus-operator stable/prometheus-operator --wait - 
   namespace=prometheus-operator -f values.yaml
 - kubectl port-forward -n prometheus-operator service/prometheus-operator-grafana 8080:80
 - kubectl appyl -f { <deployment, service, service-monitor> }
 - OPTIONAL:
        kubectl port-forward -n monitoring service/nginx-monitoring 9113:9113
        kubectl port-forward -n monitoring service/nginx-monitoring 8888:8888

## Как проверить работоспособность:
 - Grafana - http://localhost:8080
 - Check - http://localhost:8888/basic_status
 - Check - http://localhost:9113/metrics

## PR checklist:
 - [ ] Выставлен label с номером домашнего задания
